### PR TITLE
VC-3423 Revert immutable

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -1,25 +1,24 @@
 'use strict'
 
-const state = {}
+const Immutable = require('immutable')
+let state = new Immutable.Map({})
 const events = require('./events')
 const CakeException = require('./exception')
 const eventScope = 'state-change'
 module.exports = {
   set: function (key, value, data) {
-    state[key] = value
+    state = state.set(key, Immutable.fromJS(value))
     events.publish('app', eventScope, key, [value].concat(data))
   },
   get: function (key) {
-    if (typeof state[key] !== 'undefined') {
-      return JSON.parse(JSON.stringify(state[key]))
-    }
-    return null
+    const data = state.get(key)
+    return data instanceof Immutable.Collection ? data.toJS() : data
   },
   delete: function (key) {
-    delete state[key]
+    state = state.delete(key)
   },
   info: function () {
-    return JSON.parse(JSON.stringify(state))
+    return state.toJS()
   },
   onChange: function (key, fn, options) {
     if (fn instanceof Function) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/wpbakery/vc-cake#readme",
   "dependencies": {
-    "immutable": "4.0.0",
+    "immutable": "4.3.4",
     "lodash": "4.17.21",
     "murmurhash": "2.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1943,10 +1943,10 @@ ignore@^5.1.1:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
-immutable@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0.tgz#b86f78de6adef3608395efb269a91462797e2c23"
-  integrity sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==
+immutable@4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.4.tgz#2e07b33837b4bb7662f288c244d1ced1ef65a78f"
+  integrity sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"


### PR DESCRIPTION
1. Update the ImmutableJS library version
2. Revert the ImmutableJS library, as `JSON.parse(JSON.stringify(state[key]))` affects performance in a bad way in a Safari browser.